### PR TITLE
Fix bowtie2 not resuming on single end data.

### DIFF
--- a/tracer
+++ b/tracer
@@ -240,12 +240,19 @@ class Launcher():
         
         if should_resume:
             for locus in locus_names:
-                aligned_read_path = "{}/aligned_reads/{}_{}_".format(output_dir, cell_name, locus)
-                fastq1_out= "{}1.fastq".format(aligned_read_path)
-                fastq2_out= "{}2.fastq".format(aligned_read_path)
-                if os.path.isfile(fastq1_out) and os.path.isfile(fastq2_out):
-                    print "Resuming with existing TCRA and B reads"
-                    return
+                if single_end:
+                    aligned_read_path = "{}/aligned_reads/{}_{}".format(output_dir, cell_name, locus)
+                    fastq_out = "{}.fastq".format(aligned_read_path)
+                    if os.path.isfile(fastq_out):
+                        print "Resume with existing TCRA and B reads"
+                        return
+                else:
+                    aligned_read_path = "{}/aligned_reads/{}_{}_".format(output_dir, cell_name, locus)
+                    fastq1_out= "{}1.fastq".format(aligned_read_path)
+                    fastq2_out= "{}2.fastq".format(aligned_read_path)
+                    if os.path.isfile(fastq1_out) and os.path.isfile(fastq2_out):
+                        print "Resuming with existing TCRA and B reads"
+                        return
         
         for locus in locus_names:
             print "##{}##".format(locus)


### PR DESCRIPTION
Current TraCeR script expects existence of `$sample_$region_{1,2}.fastq` in order to resume from `bowtie2` output. With single end data, `_{1,2}` are never appended and so read alignment is never resumed from. This is just a simple fix adding a conditional on `single_end` value.