### PR TITLE
Add '/1' to headers of single-end fastq files for compatibility with Trinity

### DIFF
--- a/tracerlib/tracer_func.py
+++ b/tracerlib/tracer_func.py
@@ -1016,7 +1016,7 @@ def bowtie2_alignment(bowtie2, ncores, receptor, loci, output_dir, cell_name,
                             seq = str(Seq(seq).reverse_complement())
                             qual = qual[::-1]
                         fastq_out.write(
-                            "@{name}\n{seq}\n+\n{qual}\n".format(name=name,
+                            "@{name}/1\n{seq}\n+\n{qual}\n".format(name=name,
                                                                  seq=seq,
                                                                  qual=qual))
                 fastq_out.close()


### PR DESCRIPTION
Trinity fails in single-end mode unless the fastq headers end with '/1' or '/2'. TraCeR now adds '/1' at the end of each fastq header if run in single-end mode.