### PR TITLE
Add IGDATA environmental variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN cd /ncbi-igblast-1.7.0/bin/ && wget -r ftp://ftp.ncbi.nih.gov/blast/executab
 	mv ftp.ncbi.nih.gov/blast/executables/igblast/release/internal_data . && \
 	mv ftp.ncbi.nih.gov/blast/executables/igblast/release/optional_file . && \
 	rm -r ftp.ncbi.nih.gov
+ENV IGDATA /ncbi-igblast-1.7.0/bin/
 
 #aligners - kallisto and salmon
 RUN wget https://github.com/pachterlab/kallisto/releases/download/v0.43.1/kallisto_linux-v0.43.1.tar.gz


### PR DESCRIPTION
This variable must be set according to https://github.com/Teichlab/tracer#installing-igblast, otherwise `assembly` fails with `BLAST query/options error: Germline annotation database mouse/mouse_TR_V could not be found in [internal_data] directory`